### PR TITLE
Migrate to faster-whisper for improved transcription speed and accuracy

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,14 +3,14 @@ from flask import Flask, request, jsonify
 import os
 
 app = Flask(__name__)
-model = WhisperModel("medium", compute_type="int8")
+model = WhisperModel("large", compute_type="int8")
 
 @app.route("/transcribe", methods=["POST"])
 def transcribe():
     if "audio" not in request.files:
         return jsonify({"success": False, "message": "No audio file provided"}), 400
 
-    audio_file = request.files["aaudio"]
+    audio_file = request.files["audio"]
     audio_path = os.path.join("temp_audio", audio_file.filename)
     audio_file.save(audio_path)
 

--- a/app.py
+++ b/app.py
@@ -1,24 +1,29 @@
-# whisper_service.py
-import whisper
+from faster_whisper import WhisperModel
 from flask import Flask, request, jsonify
 import os
 
 app = Flask(__name__)
-model = whisper.load_model("medium")  # Load the Whisper model
+model = WhisperModel("medium", compute_type="int8")
 
 @app.route("/transcribe", methods=["POST"])
 def transcribe():
     if "audio" not in request.files:
         return jsonify({"success": False, "message": "No audio file provided"}), 400
 
-    audio_file = request.files["audio"]
+    audio_file = request.files["aaudio"]
     audio_path = os.path.join("temp_audio", audio_file.filename)
     audio_file.save(audio_path)
 
     try:
-        result = model.transcribe(audio_path, language="ar")
-        text = result["text"]
-        return jsonify({"success": True, "text": text})
+        segments, info = model.transcribe(audio_path, language="ar")
+        text = "".join([segment.text for segment in segments])
+
+        return jsonify({
+            "success": True,
+            "text": text,
+            "language": info.language,
+            "confidence": info.language_probability
+        })
     except Exception as e:
         return jsonify({"success": False, "error": str(e)}), 500
     finally:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ fastapi
 uvicorn
 python-multipart
 flask
-git+https://github.com/openai/whisper.git
+faster-whisper


### PR DESCRIPTION
Replace the OpenAI Whisper implementation with faster-whisper to enhance transcription performance and upgrade the model to "large" for better accuracy. Fix audio file retrieval in the transcribe endpoint.